### PR TITLE
Limit context to passed object

### DIFF
--- a/jst.js
+++ b/jst.js
@@ -3,5 +3,7 @@
 var _ = require('underscore');
 
 exports.translate = function (load) {
-  return 'module.exports = ' + _.template(load.source).source + ';';
+  return 'module.exports = function(object) {\n' +
+            'return ' + _.template(load.source).source + '.apply(object);\n'+
+          '};';
 };

--- a/test/sample.jst
+++ b/test/sample.jst
@@ -1,1 +1,1 @@
-<div><%=name%></div>
+<div><%= this.name %></div>


### PR DESCRIPTION
Instead of passing the context from the caller of the exported template function, this change will limit the context of the template to the object that's passed.

Obviously a breaking change, so I don't know how you want to handle versioning. Maybe this could be configurable, but I don't know how to do that with System.js plugins.
## Example

``` html
<!-- templates/hello.jst.js -->
<div><%= this.text %></div>
```
### Before

``` javascript
// hello.js
import template from 'templates/hello.jst';

let myObj = {
  data: 'data',
  template: template
};
myObj.template();
// => <div>data</div>
```
### After

``` javascript
// hello.js
import template from 'templates/hello.jst';

template({
  data: 'data'
});
// => <div>data</div>
```
